### PR TITLE
US-5/11: add feature files for US5.1 and 11.1

### DIFF
--- a/ElectricChargingStation/src/test/resources/org/example/Customer/viewInvoices.feature
+++ b/ElectricChargingStation/src/test/resources/org/example/Customer/viewInvoices.feature
@@ -6,17 +6,16 @@ Feature: View invoices
 
   @US5.1
   Scenario: View an empty invoice list
-    Given a customer "Alice" exists with balance 0
+    Given a customer "Alice" with email "alice@test.com" exists with balance 0
     When I view the invoice items of customer "Alice"
     Then the invoice item count for customer "Alice" is 0
     And the invoice items for customer "Alice" show the following:
     """
-    (no items)
     """
 
   @US5.1
   Scenario: View invoice items after a top-up
-    Given a customer "Alice" exists with balance 0
+    Given a customer "Alice" with email "alice@test.com" exists with balance 0
     And customer "Alice" top-ups the amount 50
     When I view the invoice items of customer "Alice"
     Then the invoice item count for customer "Alice" is 1
@@ -27,7 +26,7 @@ Feature: View invoices
 
   @US5.1
   Scenario: View invoice items after multiple top-ups
-    Given a customer "Alice" exists with balance 0
+    Given a customer "Alice" with email "alice@test.com" exists with balance 0
     And customer "Alice" top-ups the amount 30
     And customer "Alice" top-ups the amount 20
     And customer "Alice" top-ups the amount 50
@@ -42,13 +41,13 @@ Feature: View invoices
 
   @US5.1
   Scenario: View invoice items containing top-ups and charges mixed
-    Given a customer "Alice" exists with balance 0
+    Given a customer "Alice" with email "alice@test.com" exists with balance 0
     And customer "Alice" top-ups the amount 50
     And a location "Prater" at "Praterallee 1, 1020 Wien" exists with rates:
       | type | price_per_kwh | parking_price_per_hour |
       | AC   | 0.35          | 0.10                   |
       | DC   | 0.55          | 0.20                   |
-    And location "Prater" has a charger of type "AC" with status "available"
+    And location "Prater" has a charger of type "AC" with status "in operation free"
     And customer "Alice" performs a charging session at charger ID 1 of location "Prater" with:
       | start_time | duration_minutes |
       | 14:00      | 25               |

--- a/ElectricChargingStation/src/test/resources/org/example/Owner/viewInvoices.feature
+++ b/ElectricChargingStation/src/test/resources/org/example/Owner/viewInvoices.feature
@@ -11,13 +11,12 @@ Feature: View Invoices
     When I view all invoices
     Then I see the following invoice overview:
     """
-    (no customers)
     """
 
   @US11.1
   Scenario: View all invoices for multiple customers with only top-ups
-    Given a customer "Alice" exists with balance 0
-    And a customer "Bob" exists with balance 0
+    Given a customer "Alice" with email "alice@test.com" exists with balance 0
+    And a customer "Bob" with email "bob@test.com" exists with balance 0
     And customer "Alice" top-ups the amount 50
     And customer "Bob" top-ups the amount 20
     And customer "Bob" top-ups the amount 30
@@ -34,15 +33,15 @@ Feature: View Invoices
 
   @US11.1
   Scenario: View all invoices including charging sessions
-    Given a customer "Alice" exists with balance 0
-    And a customer "Bob" exists with balance 0
+    Given a customer "Alice" with email "alice@test.com" exists with balance 0
+    And a customer "Bob" with email "bob@test.com" exists with balance 0
     And customer "Alice" top-ups the amount 50
     And customer "Bob" top-ups the amount 100
     And a location "Prater" at "Praterallee 1, 1020 Wien" exists with rates:
       | type | price_per_kwh | parking_price_per_hour |
       | AC   | 0.35          | 0.10                   |
       | DC   | 0.55          | 0.20                   |
-    And location "Prater" has a charger of type "AC" with status "available"
+    And location "Prater" has a charger of type "AC" with status "in operation free"
     And customer "Bob" performs a charging session at charger ID 1 of location "Prater" with:
       | start_time | duration_minutes |
       | 18:00      | 20               |


### PR DESCRIPTION
When creating the charger, the power output in kW must be set directly inside the charger, depending on the type.

How charging costs are calculated

Assumptions: Each charger has a fixed power rating (power_kw) depending on its type:
Example: AC → 11 kW, DC → e.g., 50 kW
Each location defines two price components per charger type: 
price_per_kwh (€/kWh) — energy cost 
parking_price_per_hour (€/h) — parking/time cost

Step-by-step formulas:
1) Calculate energy delivered (kWh)
energy_kwh = (duration_minutes / 60) * power_kw

Example: duration = 25 min, power_kw = 11 (because its an AC charger we are using)
energy_kwh = (25/60) * 11 ≈ 4.583 kWh

2) Energy cost (€)
energy_cost = energy_kwh * price_per_kwh

Example: 4.583 kWh * 0.35 €/kWh ≈ 1.60 €

3) Parking/time cost (€)
parking_cost = (duration_minutes / 60) * parking_price_per_hour

Example: (25 / 60) * 0.10 €/h ≈ 0.04 €

4) Total cost (€)
total_cost = energy_cost + parking_cost

Example: 1.60 + 0.04 = 1.64 €

5) Update customer balance
new_balance = previous_balance - total_cost

Example: 50.00 - 1.64 = 48.36 €

